### PR TITLE
broker is failing on startup due to lack of cluster id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
       KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
   schema-registry:
     image: confluentinc/cp-schema-registry:7.6.0
     hostname: schema-registry


### PR DESCRIPTION
I've found it's necessary to specify a CLUSTER_ID for the Kafka broker.